### PR TITLE
Add support for Adafruit Circuit Playground Bluefruit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A version of the Lisp programming language for boards based on the ARM processor
 * Adafruit ItsyBitsy M0, Feather M0, and Gemma M0.
 * Adafruit Metro M4, ItsyBitsy M4, Feather M4, and Grand Central M4.
 * Adafruit PyBadge and PyGamer.
-* Adafruit CLUE and ItsyBitsy nRF52840.
+* Adafruit CLUE, ItsyBitsy and Circuit Playground Bluefruit nRF52840.
 * Raspberry Pi Pico and Raspberry Pi Pico W.
 * BBC Micro Bit.
 * Maxim MAX32620FTHR.

--- a/ulisp-arm.ino
+++ b/ulisp-arm.ino
@@ -2306,7 +2306,7 @@ const int scale[] PROGMEM = {4186,4435,4699,4978,5274,5588,5920,6272,6645,7040,7
 
 void playnote (int pin, int note, int octave) {
 #if defined(ARDUINO_NRF52840_CLUE) || defined(ARDUINO_NRF52840_CIRCUITPLAY) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_ADAFRUIT_QTPY_RP2040)
-  if (!(pin>=26 && pin<=29)) error(ANALOGREAD, invalidpin, number(pin));
+  // if (!(pin>=26 && pin<=29)) error(ANALOGREAD, invalidpin, number(pin));
   int prescaler = 8 - octave - note/12;
   if (prescaler<0 || prescaler>8) error(NOTE, PSTR("octave out of range"), number(prescaler));
   tone(pin, scale[note%12]>>prescaler);

--- a/ulisp-arm.ino
+++ b/ulisp-arm.ino
@@ -147,7 +147,11 @@ Adafruit_ST7735 tft = Adafruit_ST7735(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RS
   #define DATAFLASH
   #define FLASHSIZE 2048000               /* 2 MBytes */
   #define CODESIZE 256                    /* Bytes */
-  #define STACKDIFF 1200
+  #if defined(ARDUINO_NRF52840_CIRCUITPLAY)
+    #define STACKDIFF 0
+  #else
+    #define STACKDIFF 1200
+  #endif
   #define CPU_NRF52840
 
 #elif defined(MAX32620)

--- a/ulisp-arm.ino
+++ b/ulisp-arm.ino
@@ -142,7 +142,7 @@ Adafruit_ST7735 tft = Adafruit_ST7735(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RS
   #define STACKDIFF 320
   #define CPU_NRF51822
 
-#elif defined(ARDUINO_NRF52840_ITSYBITSY) || defined(ARDUINO_NRF52840_CLUE)
+#elif defined(ARDUINO_NRF52840_ITSYBITSY) || defined(ARDUINO_NRF52840_CLUE) || defined(ARDUINO_NRF52840_CIRCUITPLAY)
   #define WORKSPACESIZE (21120-SDSIZE)    /* Objects (8*bytes) */
   #define DATAFLASH
   #define FLASHSIZE 2048000               /* 2 MBytes */
@@ -2235,6 +2235,8 @@ void checkanalogread (int pin) {
   if (!(pin>=14 && pin<=20)) error(ANALOGREAD, invalidpin, number(pin));
 #elif defined(ARDUINO_NRF52840_CLUE)
   if (!((pin>=0 && pin<=4) || pin==10 || pin==12 || pin==16)) error(ANALOGREAD, invalidpin, number(pin));
+#elif defined(ARDUINO_NRF52840_CIRCUITPLAY)
+  if (!(pin==0 || (pin>=2 && pin<=3) || pin==6 || (pin>=9 && pin<=10) || (pin>=22 && pin<=23))) error(ANALOGREAD, invalidpin, number(pin));
 #elif defined(MAX32620)
   if (!(pin>=49 && pin<=52)) error(ANALOGREAD, invalidpin, number(pin));
 #elif defined(ARDUINO_TEENSY40)
@@ -2281,6 +2283,8 @@ void checkanalogwrite (int pin) {
   if (!(pin>=0 && pin<=25)) error(ANALOGWRITE, invalidpin, number(pin));
 #elif defined(ARDUINO_NRF52840_CLUE)
   if (!(pin>=0 && pin<=46)) error(ANALOGWRITE, invalidpin, number(pin));
+#elif defined(ARDUINO_NRF52840_CIRCUITPLAY)
+  if (!(pin>=0 && pin<=35)) error(ANALOGWRITE, invalidpin, number(pin));
 #elif defined(MAX32620)
   if (!((pin>=20 && pin<=29) || pin==32 || (pin>=40 && pin<=48))) error(ANALOGWRITE, invalidpin, number(pin));
 #elif defined(ARDUINO_TEENSY40)
@@ -2297,7 +2301,7 @@ void checkanalogwrite (int pin) {
 const int scale[] PROGMEM = {4186,4435,4699,4978,5274,5588,5920,6272,6645,7040,7459,7902};
 
 void playnote (int pin, int note, int octave) {
-#if defined(ARDUINO_NRF52840_CLUE) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_ADAFRUIT_QTPY_RP2040)
+#if defined(ARDUINO_NRF52840_CLUE) || defined(ARDUINO_NRF52840_CIRCUITPLAY) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_ADAFRUIT_QTPY_RP2040)
   if (!(pin>=26 && pin<=29)) error(ANALOGREAD, invalidpin, number(pin));
   int prescaler = 8 - octave - note/12;
   if (prescaler<0 || prescaler>8) error(NOTE, PSTR("octave out of range"), number(prescaler));
@@ -2308,7 +2312,7 @@ void playnote (int pin, int note, int octave) {
 }
 
 void nonote (int pin) {
-#if defined(ARDUINO_NRF52840_CLUE) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_ADAFRUIT_QTPY_RP2040)
+#if defined(ARDUINO_NRF52840_CLUE) || defined(ARDUINO_NRF52840_CIRCUITPLAY) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_ADAFRUIT_QTPY_RP2040)
   noTone(pin);
 #else
   (void) pin;


### PR DESCRIPTION
Add support for Adafruit Circuit Playground Bluefruit.

With STACKSIZE > 0 it gives stack overflows for the benchmarks "Hofstadter Q sequence" and "Two-dimensional recursive function Q2".

Why does function playnote() check the pin in that range? That should be broken on Adafruit CLUE, too, so I removed it.